### PR TITLE
Make /opt/magpie/tmp writable for all users

### DIFF
--- a/Docker/magpie/Dockerfile
+++ b/Docker/magpie/Dockerfile
@@ -47,5 +47,7 @@ COPY demo/                               /opt/magpie/demo/
 COPY main.py                             /opt/magpie
 COPY magpie_logo.txt                     /opt/magpie
 
+RUN mkdir -p /opt/magpie/tmp && chmod ugo+rw /opt/magpie/tmp
+
 RUN chmod +x                             /opt/magpie/entrypoint.sh
 ENTRYPOINT [ "/opt/magpie/entrypoint.sh" ]


### PR DESCRIPTION
Running for `Docker/docker_entrypoint_check.sh` with a specified user results in the error message
> Checking...
> mkdir: cannot create directory '/opt/magpie/tmp': Permission denied

This allows the directory to exist already with permissions for anyone to read/write.